### PR TITLE
v1.0.4: Add Total Cleaning Time sensor; document non-implementable features

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ You'll need the following information during setup:
 ### Sensors
 - Battery level
 - Running status
-- Cleaning statistics (Total Cleaning Area, Total Cleaning Count)
+- Cleaning statistics (Total Cleaning Area, Total Cleaning Count, Total Cleaning Time)
 
 ### Select
 - Cleaning mode and water level selection
@@ -106,6 +106,10 @@ You'll need the following information during setup:
 
 Selecting individual rooms to clean from Home Assistant is **not implementable** through this integration's local-only design, and there are no plans to add it. Investigation on FW 7.0.168 confirmed that the Eufy mobile app sends room-selection commands to the device via the Tuya cloud / Eufy's encrypted P2P channel, and the room IDs / map data never travel over the local LAN. The same constraint applies broadly to other Home Assistant integrations targeting this model, so no realistic workaround is expected. See the [`feature/room-cleaning`](https://github.com/tkoba1974/ha-eufy-robovac-s1-pro/tree/feature/room-cleaning) branch for the full investigation log.
 
+### Maintenance/consumable status is not exposed
+
+The per-component remaining lifetime shown on the Eufy app's "Maintenance" screen (rotating mop, dirty water tank, mop cleaning tray, high-performance filter, side brush, rotating brush, sensors, dirty water tank filter) is **not available** through this integration. Investigation on FW 7.0.168 confirmed that none of these eight values are published over the local Tuya channel — the Eufy app fetches them via the cloud / encrypted P2P channel, the same path as room data. For the same reason, resetting consumables from Home Assistant is also not supported; reset must be done from the Eufy app.
+
 ## Contributing
 
 Please report bugs and feature requests via [Issues](https://github.com/tkoba1974/ha-eufy-robovac-s1-pro/issues).
@@ -113,6 +117,13 @@ Please report bugs and feature requests via [Issues](https://github.com/tkoba197
 Pull requests are welcome!
 
 ## Changelog
+
+### v1.0.4
+- **Add: Total Cleaning Time sensor** — New diagnostic sensor exposing cumulative cleaning time in minutes (matches the "合計時間 / Total Time" value shown in the Eufy app's cleaning history). Value persists across restarts via `RestoreEntity`.
+- **Fix: DPS 167 statistics parser robustness** — Replaced fixed byte-position parsing with a proper protobuf walker so Total Cleaning Area continues to decode correctly when the cumulative value crosses 2-byte varint boundaries.
+- **Docs: Known Limitations expanded with feature-scope decisions** — The README's "Known Limitations" section now explicitly documents two feature areas that are *not implementable* under this integration's local-LAN-only design (verified empirically on FW 7.0.168):
+  - **Room-specific cleaning, floor-plan switching, map management** — first added to the README between v1.0.3 and v1.0.4 but not surfaced in any prior release notes; called out here so users tracking releases can see the decision. The Eufy app sends room/map commands via the Tuya cloud / Eufy's encrypted P2P channel, which this integration cannot observe or replay.
+  - **Maintenance/consumable status (8 items)** — newly verified on 2026-05-02. None of the per-component remaining-lifetime values shown on the Eufy app's "Maintenance" screen (rotating mop, dirty water tank, mop cleaning tray, high-performance filter, side brush, rotating brush, sensors, dirty water tank filter) are published over the local Tuya channel. Resetting consumables from Home Assistant is also not supported; reset must be done from the Eufy app.
 
 ### v1.0.3
 - **Fix: Eufy API login failure** — Updated login headers (`User-Agent`, `clientType`, `client_secret` key name) to match the latest Eufy Home app (v3.1.3). Added v1/v2 endpoint fallback to handle potential future API endpoint deprecation.

--- a/custom_components/eufy_robovac_s1_pro/manifest.json
+++ b/custom_components/eufy_robovac_s1_pro/manifest.json
@@ -7,7 +7,7 @@
     "requirements": ["requests>=2.31.0", "cryptography>=41.0.0"],
     "iot_class": "local_polling",
     "config_flow": true,
-    "version": "1.0.3",
+    "version": "1.0.4",
     "dependencies": [],
     "integration_type": "device"
 }

--- a/custom_components/eufy_robovac_s1_pro/sensor.py
+++ b/custom_components/eufy_robovac_s1_pro/sensor.py
@@ -41,83 +41,73 @@ def decode_varint(data: bytes, start_pos: int) -> tuple[int, int]:
 
 
 def parse_dps167_statistics(dps167_value: str) -> dict[str, int | None]:
-    """Parse statistics from DPS 167.
-    
-    Based on detailed analysis of S1 Pro data:
-    - Total count: Last field (varint, can be 1 or 2 bytes)
-    - Total area: 2-byte varint at fixed position 14-15
-    - Total time: Not yet identified in DPS 167
-    
-    Args:
-        dps167_value: Base64-encoded DPS 167 value
-        
-    Returns:
-        dict with keys: total_count, total_area, total_time_mins
+    """Parse cumulative cleaning statistics from DPS 167.
+
+    DPS 167 is a length-prefixed protobuf with two top-level submessages:
+        field 1 (sub): current/last session info (time_s, area)
+        field 2 (sub): cumulative totals (time_s, area, count)
+
+    Verified on FW 7.0.168 against the Eufy app's "掃除履歴" header
+    (count / area / total time) — see ``feature/room-cleaning`` branch
+    notes for the raw byte walkthrough.
     """
-    stats = {
+    stats: dict[str, int | None] = {
         "total_count": None,
         "total_area": None,
         "total_time_mins": None,
     }
-    
+
     try:
-        # Decode base64
         data = base64.b64decode(dps167_value)
-        
-        if len(data) == 0:
+        if len(data) < 2:
             return stats
-        
-        # 1. Total count is in the last field as varint
-        # The last field has tag 0x18 (field #3, wire_type=0)
-        # It can be 1 byte (0-127) or 2+ bytes (128+)
-        
-        # Find the last field by looking for tag 0x18 from the end
-        if len(data) >= 2 and data[-2] == 0x18:
-            # Tag found, next byte is the value (1-byte varint)
-            stats["total_count"] = data[-1]
-        elif len(data) >= 3 and data[-3] == 0x18:
-            # Tag found, next 2 bytes are the value (2-byte varint)
-            byte1 = data[-2]
-            byte2 = data[-1]
-            if byte1 & 0x80:  # MSB set = multi-byte varint
-                stats["total_count"] = (byte1 & 0x7F) + (byte2 << 7)
-            else:
-                # Single byte value
-                stats["total_count"] = byte1
-        elif len(data) >= 4 and data[-4] == 0x18:
-            # Tag found, next 3 bytes are the value (3-byte varint, for 16384+)
-            byte1 = data[-3]
-            byte2 = data[-2]
-            byte3 = data[-1]
-            if (byte1 & 0x80) and (byte2 & 0x80):
-                stats["total_count"] = (byte1 & 0x7F) + ((byte2 & 0x7F) << 7) + (byte3 << 14)
-            elif byte1 & 0x80:
-                # 2-byte varint
-                stats["total_count"] = (byte1 & 0x7F) + (byte2 << 7)
-            else:
-                # Single byte
-                stats["total_count"] = byte1
-        
-        # 2. Total area is at fixed position 14-15 as 2-byte varint
-        # Confirmed positions for data length 18-19 bytes
-        if len(data) >= 16:
-            byte1 = data[14]
-            byte2 = data[15]
-            
-            # Decode 2-byte varint
-            if byte1 & 0x80:  # MSB set = multi-byte varint
-                area = (byte1 & 0x7F) + (byte2 << 7)
-                stats["total_area"] = area
-            else:
-                # Single byte value (unlikely for area, but handle it)
-                stats["total_area"] = byte1
-        
-        # 3. Total time: not yet reliably identified
-                
+
+        # Strip the 1-byte length prefix.
+        body = data[1:]
+        fields = _parse_protobuf_fields(body)
+
+        cumulative = fields.get(2)
+        if cumulative is None:
+            return stats
+
+        cumulative_fields = _parse_protobuf_fields(cumulative)
+        total_time_s = cumulative_fields.get(1)
+        if isinstance(total_time_s, int):
+            stats["total_time_mins"] = total_time_s // 60
+        if isinstance(cumulative_fields.get(2), int):
+            stats["total_area"] = cumulative_fields[2]
+        if isinstance(cumulative_fields.get(3), int):
+            stats["total_count"] = cumulative_fields[3]
     except Exception as e:
-        _LOGGER.debug(f"Error parsing DPS 167: {e}")
-    
+        _LOGGER.debug("Error parsing DPS 167: %s", e)
+
     return stats
+
+
+def _parse_protobuf_fields(data: bytes) -> dict[int, int | bytes]:
+    """Walk a protobuf message and return {field_number: value}.
+
+    Only varint (wire type 0) and length-delimited (wire type 2) fields are
+    decoded — that's all DPS 167 uses. Repeated fields keep the last value,
+    which is sufficient for the singular fields we care about.
+    """
+    fields: dict[int, int | bytes] = {}
+    pos = 0
+    while pos < len(data):
+        tag, pos = decode_varint(data, pos)
+        field_number = tag >> 3
+        wire_type = tag & 0x07
+        if wire_type == 0:
+            value, pos = decode_varint(data, pos)
+            fields[field_number] = value
+        elif wire_type == 2:
+            length, pos = decode_varint(data, pos)
+            fields[field_number] = data[pos:pos + length]
+            pos += length
+        else:
+            # Unknown wire type — bail out rather than risk misalignment.
+            break
+    return fields
 
 
 async def async_setup_entry(
@@ -145,8 +135,7 @@ async def async_setup_entry(
         # Add statistics sensors (from DPS 167)
         devices.append(TotalCleaningCountSensor(coordinator=coordinator))
         devices.append(TotalCleaningAreaSensor(coordinator=coordinator))
-        # TODO: Uncomment when time data position is identified
-        # devices.append(TotalCleaningTimeSensor(coordinator=coordinator))
+        devices.append(TotalCleaningTimeSensor(coordinator=coordinator))
 
     if devices:
         return async_add_devices(devices)
@@ -445,41 +434,60 @@ class TotalCleaningAreaSensor(CoordinatorTuyaDeviceUniqueIDMixin, CoordinatorEnt
             return self._last_valid_area
 
 
-# TODO: Uncomment when time data position is identified in DPS 167 or DPS 168
-# class TotalCleaningTimeSensor(CoordinatorTuyaDeviceUniqueIDMixin, CoordinatorEntity, SensorEntity):
-#     """Sensor for total cleaning time from DPS 167.
-#     
-#     NOTE: The exact position of time data has not been reliably identified yet.
-#     Current investigation shows:
-#     - Not found as simple varint at any fixed position
-#     - May be split into hours/minutes components
-#     - May be stored in seconds (requires 3-byte varint)
-#     - May be in DPS 168 instead of DPS 167
-#     
-#     TODO: Analyze logs with larger time differences to identify the pattern.
-#     """
-#     
-#     _attr_entity_category = EntityCategory.DIAGNOSTIC
-#     _attr_name = "Total Cleaning Time"
-#     _attr_icon = "mdi:clock-outline"
-#     _attr_device_class = SensorDeviceClass.DURATION
-#     _attr_native_unit_of_measurement = UnitOfTime.MINUTES
-#     _attr_state_class = SensorStateClass.TOTAL_INCREASING
-#     
-#     @property
-#     def available(self) -> bool:
-#         """Return if entity is available."""
-#         return self.coordinator.data is not None and "167" in self.coordinator.data
-#     
-#     @property
-#     def native_value(self) -> int | None:
-#         """Return the total cleaning time in minutes."""
-#         if not self.coordinator.data:
-#             return None
-#         
-#         dps167 = self.coordinator.data.get("167", "")
-#         if not dps167:
-#             return None
-#         
-#         stats = parse_dps167_statistics(dps167)
-#         return stats.get("total_time_mins")
+class TotalCleaningTimeSensor(CoordinatorTuyaDeviceUniqueIDMixin, CoordinatorEntity, RestoreEntity, SensorEntity):
+    """Sensor for total cleaning time from DPS 167.
+
+    累積値のため RestoreEntity を使用して再起動後も最終値を保持します。
+    """
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_name = "Total Cleaning Time"
+    _attr_icon = "mdi:clock-outline"
+    _attr_device_class = SensorDeviceClass.DURATION
+    _attr_native_unit_of_measurement = UnitOfTime.MINUTES
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._last_valid_minutes = None
+
+    async def async_added_to_hass(self) -> None:
+        """Restore last known value on startup."""
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state and last_state.state not in (None, "unknown", "unavailable"):
+            try:
+                self._last_valid_minutes = int(last_state.state)
+                _LOGGER.debug(
+                    "Restored Total Cleaning Time: %s min", self._last_valid_minutes
+                )
+            except (ValueError, TypeError):
+                pass
+
+    @property
+    def available(self) -> bool:
+        """Available if we have live data or a restored value."""
+        has_live = self.coordinator.data is not None and "167" in self.coordinator.data
+        return has_live or self._last_valid_minutes is not None
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the total cleaning time in minutes."""
+        if not self.coordinator.data:
+            return self._last_valid_minutes
+
+        dps167 = self.coordinator.data.get("167", "")
+        if not dps167:
+            return self._last_valid_minutes
+
+        stats = parse_dps167_statistics(dps167)
+        new_minutes = stats.get("total_time_mins")
+
+        if new_minutes is None:
+            return self._last_valid_minutes
+
+        if self._last_valid_minutes is None or new_minutes >= self._last_valid_minutes:
+            self._last_valid_minutes = new_minutes
+            return new_minutes
+        else:
+            return self._last_valid_minutes


### PR DESCRIPTION
## Summary

- Add **Total Cleaning Time** sensor (cumulative cleaning time in minutes from DPS 167, matches the Eufy app's "合計時間"). Persists across restarts via `RestoreEntity`.
- Replace the fragile fixed-position parser in `parse_dps167_statistics` with a proper protobuf walker — verified against 4 samples (3 historical + 1 live, all matching the Eufy app exactly).
- Document feature-scope decisions in README **Known Limitations** so users tracking releases see them: room-specific cleaning (carryover from prior README update) + maintenance/consumable status for the 8 components shown on the Eufy app's Maintenance screen (newly verified on 2026-05-02 — none of these values are published on the local Tuya channel).
- Bump manifest version to 1.0.4.

## Test plan

- [x] Unit-equivalent: new `parse_dps167_statistics` returns `time_min=6436, area=5232, count=280` for the live DPS 167 sample, matching the app's "280回 / 5,232㎡ / 107h 16min".
- [x] Live HA reload: new `Total Cleaning Time` entity appears (showing 6,436 min) alongside the existing Total Cleaning Count and Total Cleaning Area.
- [x] Existing Total Cleaning Count / Area sensors continue to show correct values via the new walker.
- [ ] Reviewer: verify monotonic-decrease guard behaves like the count/area sensors (held during transient empty/invalid DPS 167 payloads).
- [ ] Reviewer: verify `RestoreEntity` restores the last cumulative time after HA restart before the first poll completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
