### PR TITLE
docs: clarify consumable reset is not implemented (not channel-impossible)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,9 @@ Selecting individual rooms to clean from Home Assistant is **not implementable**
 
 ### Maintenance/consumable reset is not supported
 
-Resetting consumables (side brush, rolling brush, filter, etc.) from Home Assistant is **not supported** — the local Tuya channel does not appear to carry the reset command for this device, so users must reset consumables from the Eufy app. The remaining-% values themselves *are* exposed as sensors (see Supported Entities → Sensors); only the reset action is missing.
+Resetting consumables (side brush, rolling brush, filter, etc.) from Home Assistant is **not currently supported** — reset must be done from the Eufy app. The remaining-% values themselves *are* exposed as sensors (see Supported Entities → Sensors); only the reset action is missing.
+
+The reset is technically reachable: per the Eufy/Tuya cloud `consumable.proto` (referenced in [jeppesens/eufy-clean#126](https://github.com/jeppesens/eufy-clean/pull/126)), the reset is a write of a `ConsumableRequest { reset_types: [<enum>] }` protobuf to **DPS 168** (the same DPS we read for status). It is not implemented here because verification would require destructively zeroing a real consumable counter, and no public confirmation exists that the legacy / local-Tuya path on the S1 Pro accepts the reset write — the reference implementation in jeppesens/eufy-clean explicitly skips reset buttons for legacy/Tuya devices.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

The v1.0.5 README said "the local Tuya channel does not appear to carry the reset command" — that wording was carried over from the (now-retracted) v1.0.4 negative conclusion and is no longer accurate now that we know what DPS 168 is.

Per jeppesens/eufy-clean#126's `commands.py`, reset is a write of a `ConsumableRequest { reset_types: [<enum>] }` protobuf to **DPS 168** (the same DPS we read for status). That reference implementation explicitly skips reset buttons for legacy/Tuya devices, and we have no public confirmation that S1 Pro accepts the reset write on the local-Tuya path. Verification would require destructively zeroing a real consumable counter, which we have decided is not worth doing for now.

The Known Limitations entry now distinguishes **"not currently implemented"** from **"not implementable"**, so a future contributor isn't misled into thinking the channel itself is the blocker (the way it is for room cleaning).

No code change, no version bump.

## Test plan

- [x] README renders cleanly
- [ ] Reviewer: confirm the new wording reads as intended (clearly says "could in principle be reachable, just not implemented and not verified")

🤖 Generated with [Claude Code](https://claude.com/claude-code)
